### PR TITLE
Rename RII.load_dispersion to RII.get_dispersion

### DIFF
--- a/src/elli/database/refractive_index_info.py
+++ b/src/elli/database/refractive_index_info.py
@@ -87,7 +87,7 @@ class RII:
     .. code-block:: python
 
         gold_material = RII.get_mat("Au", "Johnson")
-        gold_dispersion = RII.load_dispersion("Au", "Johnson")
+        gold_dispersion = RII.get_dispersion("Au", "Johnson")
     """
 
     def __init__(self) -> None:
@@ -272,9 +272,9 @@ class RII:
         Returns:
             IsotropicMaterial: A material object build from the tabulated dispersion data.
         """
-        return IsotropicMaterial(self.load_dispersion(book, page))
+        return IsotropicMaterial(self.get_dispersion(book, page))
 
-    def load_dispersion(
+    def get_dispersion(
         self, book: str, page: str
     ) -> Union[Dispersion, IndexDispersion]:
         """Load a dispersion from the refractive index database.

--- a/tests/test_refractive_index_info.py
+++ b/tests/test_refractive_index_info.py
@@ -16,10 +16,10 @@ class TestRefractiveIndexInfo:
 
     def test_dispersion_error(self):
         with pytest.raises(ValueError):
-            self.RII.load_dispersion("foo", "bar")
+            self.RII.get_dispersion("foo", "bar")
 
     def test_tabular_nk(self):
-        disp = self.RII.load_dispersion("Au", "Johnson")  # tabular nk
+        disp = self.RII.get_dispersion("Au", "Johnson")  # tabular nk
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(310.7), 1.53 + 1j * 1.893, decimal=3
@@ -29,7 +29,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_tabular_n(self):
-        disp = self.RII.load_dispersion("Xe", "Koch")  # Tabular n
+        disp = self.RII.get_dispersion("Xe", "Koch")  # Tabular n
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(234.555), 1.00084664, decimal=6
@@ -39,7 +39,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_formula_1(self):
-        disp = self.RII.load_dispersion("SrTiO3", "Dodge")  # Formula 1
+        disp = self.RII.get_dispersion("SrTiO3", "Dodge")  # Formula 1
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(500), 2.4743, decimal=4
@@ -49,7 +49,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_formula_2_tabular_k(self):
-        disp = self.RII.load_dispersion("SCHOTT-BK", "N-BK7")  # Formula 2 + k
+        disp = self.RII.get_dispersion("SCHOTT-BK", "N-BK7")  # Formula 2 + k
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(500), 1.5214 + 1j * 9.5781e-9, decimal=4
@@ -59,7 +59,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_formula_3(self):
-        disp = self.RII.load_dispersion("HOYA-NbF", "NBF1")  # Formula 3
+        disp = self.RII.get_dispersion("HOYA-NbF", "NBF1")  # Formula 3
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(500), 1.7520 + 1j * 3.9809e-9, decimal=4
@@ -69,7 +69,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_formula_4(self):
-        disp = self.RII.load_dispersion("AgCl", "Tilton")  # formula 4
+        disp = self.RII.get_dispersion("AgCl", "Tilton")  # formula 4
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(1024), 2.0213900020277, decimal=12
@@ -79,7 +79,7 @@ class TestRefractiveIndexInfo:
         )
 
     def test_formula_5(self):
-        disp = self.RII.load_dispersion("SF6", "Vukovic")  # Formula 5
+        disp = self.RII.get_dispersion("SF6", "Vukovic")  # Formula 5
 
         np.testing.assert_almost_equal(
             disp.get_refractive_index(600), 1.00072905, decimal=6


### PR DESCRIPTION
I would suggest to change the RII.load_dispersion method to RII.get_dispersion to be consistent across the module.