### PR TITLE
Adapt correct version retrieval

### DIFF
--- a/src/elli/importer/nexus.py
+++ b/src/elli/importer/nexus.py
@@ -12,7 +12,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+if np.lib.NumpyVersion(np.__version__) < "2.0.0":
     from numpy.lib.index_tricks import IndexExpression
 else:
     from numpy.lib._index_tricks_impl import IndexExpression

--- a/src/elli/importer/nexus.py
+++ b/src/elli/importer/nexus.py
@@ -12,7 +12,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-if np.version.version < "2.0.0":
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
     from numpy.lib.index_tricks import IndexExpression
 else:
     from numpy.lib._index_tricks_impl import IndexExpression


### PR DESCRIPTION
Follow what is described in the migration guide to do numpy version switching: https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#writing-numpy-version-dependent-code