### PR TITLE
Move class attributes to variables

### DIFF
--- a/src/elli/experiment.py
+++ b/src/elli/experiment.py
@@ -27,12 +27,6 @@ from .solver4x4 import Solver4x4
 class Experiment:
     """Description of a virtual experiment to simulate the behavior of a structure."""
 
-    structure = None
-    jones_vector = None
-    stokes_vector = None
-    theta_i = None
-    lbda = None
-
     def __init__(
         self,
         structure: "Structure",

--- a/src/elli/materials.py
+++ b/src/elli/materials.py
@@ -31,7 +31,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import numpy.typing as npt
-from numpy.lib.scimath import sqrt, power
+from numpy.lib.scimath import power, sqrt
 
 from .dispersions.base_dispersion import BaseDispersion
 
@@ -64,12 +64,6 @@ class Material(ABC):
 
 class SingleMaterial(Material):
     """Base class for non-mixed materials (abstract class)."""
-
-    dispersion_x = None
-    dispersion_y = None
-    dispersion_z = None
-    rotated = False
-    rotation_matrix = None
 
     @abstractmethod
     def set_dispersion(self) -> None:
@@ -125,6 +119,7 @@ class IsotropicMaterial(SingleMaterial):
             dispersion (Dispersion): Dispersion relation of all three crystal directions.
         """
         self.set_dispersion(dispersion)
+        self.rotated = False
 
     # pylint: disable=arguments-differ
     def set_dispersion(self, dispersion: BaseDispersion) -> None:
@@ -158,6 +153,7 @@ class UniaxialMaterial(SingleMaterial):
                 Dispersion relation for extraordinary crystal axis (z direction).
         """
         self.set_dispersion(dispersion_o, dispersion_e)
+        self.rotated = False
 
     # pylint: disable=arguments-differ
     def set_dispersion(
@@ -199,6 +195,7 @@ class BiaxialMaterial(SingleMaterial):
             dispersion_z (Dispersion): Dispersion relation for z crystal axes.
         """
         self.set_dispersion(dispersion_x, dispersion_y, dispersion_z)
+        self.rotated = False
 
     # pylint: disable=arguments-differ
     def set_dispersion(
@@ -227,10 +224,6 @@ class BiaxialMaterial(SingleMaterial):
 
 class MixtureMaterial(Material):
     """Abstract Class for mixed materials."""
-
-    host_material = None
-    guest_material = None
-    fraction = None
 
     def __init__(
         self, host_material: Material, guest_material: Material, fraction: float

--- a/src/elli/solver.py
+++ b/src/elli/solver.py
@@ -15,13 +15,6 @@ class Solver(ABC):
     Therefore, this class should never be called directly.
     """
 
-    experiment = None
-    structure = None
-    lbda = None
-    theta_i = None
-    jones_vector = None
-    permittivity_profile = None
-
     @abstractmethod
     def calculate(self) -> Result:
         pass

--- a/src/elli/structure.py
+++ b/src/elli/structure.py
@@ -53,11 +53,6 @@ class AbstractLayer(ABC):
 class RepeatedLayers(AbstractLayer):
     """Repeated structure of layers."""
 
-    repetitions = None  # Number of repetitions
-    before = None  # additional layers before the first period
-    after = None  # additional layers after the last period
-    layers = None  # layers to repeat
-
     def __init__(
         self,
         layers: List[AbstractLayer],
@@ -147,8 +142,6 @@ class RepeatedLayers(AbstractLayer):
 class Layer(AbstractLayer):
     """Homogeneous layer of dielectric material."""
 
-    thickness = None
-
     def __init__(self, material: Material, thickness: float) -> None:
         """New layer of material 'material', with thickness 'thickness'
 
@@ -204,10 +197,6 @@ class Layer(AbstractLayer):
 
 class InhomogeneousLayer(AbstractLayer):
     """Abstract base class for inhomogeneous layers with varying properties in z-direction."""
-
-    thickness = None
-    material = None
-    div = None
 
     def set_thickness(self, thickness: float) -> None:
         """Defines the thickness of the layer in nm.
@@ -405,10 +394,6 @@ class Structure:
     * layer succession
     * back half-space (exit)
     """
-
-    front_material = None
-    back_material = None
-    layers = []  # list of layers
 
     def __init__(
         self, front: IsotropicMaterial, layers: List[Layer], back: Material


### PR DESCRIPTION
Remove all class attributes, because they could be used to change values for all objects.