### PR TITLE
Replace m2r2 with sphinx-mdinclude

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_plotly_directive",
     "sphinx_rtd_theme",
-    "m2r2",
+    "sphinx_mdinclude",
     "sphinx_gallery.gen_gallery",
     "sphinxcontrib.mermaid",
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@
 # under `install_requires` in `setup.cfg` is also listed here!
 sphinx!=5.1.0
 sphinx_rtd_theme
-m2r2
+sphinx-mdinclude
 myst_parser
 scipy
 numpy>=1.20


### PR DESCRIPTION
Fix for the current error during documentation generation:

sphinx-mdinclude is a newer fork of m2r2 and more actively developed.
Should work as drop-in replacement.