### PR TITLE
Fix install instructions and git clone with submodule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,12 +70,12 @@ or **Miniconda**
     page. This creates a copy of the code under your account on github.
 3.  Clone this copy to your local disk
 
-         git clone https://github.com:YourLogin/pyElli.git
+         git clone --recurse-submodules https://github.com/PyEllips/pyElli
          cd pyElli
 
 4.  You should run
 
-          pip install -U pip setuptools -e .[fitting,dev]
+          pip install -e ".[fitting,dev]"
 
     which installs the package in development mode and all extra requirements in your current virtualenv.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The installers for all releases are available at the [Python Package Index (PyPI
 To install run:
 
 ```sh
-pip install pyElli[fitting]
+pip install "pyElli[fitting]"
 ```
 
 This installs pyElli with the additional fitting capabilities and interactive widgets.
@@ -66,7 +66,7 @@ The source code is hosted on [GitHub](https://github.com/PyEllips/pyElli), to ma
 the folder to install it in development mode:
 
 ```sh
-git clone https://github.com/PyEllips/pyElli
+git clone --recurse-submodules https://github.com/PyEllips/pyElli
 cd pyElli
 pip install -e ".[fitting]"
 ```

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ To install the package in your current virtual environment execute
 
     .. code-block:: shell
 
-        pip install pyElli[fitting]
+        pip install "pyElli[fitting]"
 
 This installs pyElli with the additional fitting capabilities and interactive widgets.
 If you don't want to have this functionality just drop the `[fitting]` in the end.
@@ -44,6 +44,6 @@ the folder to install it in development mode:
 
     .. code-block:: shell
 
-        git clone https://github.com/PyEllips/pyElli
+        git clone --recurse-submodules https://github.com/PyEllips/pyElli
         cd pyElli
         pip install -e .


### PR DESCRIPTION
Fixes #216

ToDo:

- [x] Check if there are any occurences of `git clone` or `pip install` in the docs and update accordingly