### PR TITLE
Fixes for Woollam importer

### DIFF
--- a/src/elli/importer/woollam.py
+++ b/src/elli/importer/woollam.py
@@ -181,11 +181,9 @@ def read_woollam_psi_delta(fname: str) -> pd.DataFrame:
         line = fobj.readline()
         while line:
             if _is_wvase_tabular(line):
-                line_number = fobj.tell()
                 file_format = "wvase"
                 break
             if _is_complete_ease_tabular(line):
-                line_number = fobj.tell()
                 file_format = "complete_ease"
                 break
             if _is_tan_cos_format(line):
@@ -194,6 +192,7 @@ def read_woollam_psi_delta(fname: str) -> pd.DataFrame:
                     "Please try using wvase's psi/delta format."
                 )
             metadata.append(line)
+            line_number = fobj.tell()
             line = fobj.readline()
         fobj.seek(line_number)
 

--- a/src/elli/importer/woollam.py
+++ b/src/elli/importer/woollam.py
@@ -46,7 +46,7 @@ def _is_wvase_tabular(line: str) -> bool:
     Returns:
         bool: True if the line is in wvase tabular layout.
     """
-    return bool(re.search(r"^(\d*\.\d*\s+){5}\d*\.\d*$", line))
+    return bool(re.search(r"^(-?\d*\.\d*\s+){5}\d*\.\d*$", line))
 
 
 def _is_complete_ease_tabular(line: str) -> bool:

--- a/tests/test_wollam.py
+++ b/tests/test_wollam.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fixtures import datadir  # pylint: disable=unused-import
+from numpy.testing import assert_almost_equal
 
 import elli
 
@@ -27,7 +28,11 @@ def test_reading_and_conv_to_woollam(datadir):
     data_cease = elli.read_woollam_rho(datadir / "complete_ease_example.dat")
 
     assert data_wvase.shape == (543,)
+    assert data_wvase.index.get_level_values(1)[0] == 300
+    assert data_wvase.index.get_level_values(1)[-1] == 1200
     assert data_cease.shape == (3264,)
+    assert_almost_equal(data_cease.index.get_level_values(1)[0], 193)
+    assert_almost_equal(data_cease.index.get_level_values(1)[-1], 1700)
 
 
 # pylint: disable=redefined-outer-name

--- a/tests/test_wollam.py
+++ b/tests/test_wollam.py
@@ -15,9 +15,9 @@ def test_reading_of_psi_delta_woollam(datadir):
     )
     data_cease = elli.read_woollam_psi_delta(datadir / "complete_ease_example.dat")
 
-    assert data_wvase.shape == (542, 2)
-    assert data_wvase_wo_dpolE.shape == (542, 2)
-    assert data_cease.shape == (3263, 2)
+    assert data_wvase.shape == (543, 2)
+    assert data_wvase_wo_dpolE.shape == (543, 2)
+    assert data_cease.shape == (3264, 2)
 
 
 # pylint: disable=redefined-outer-name
@@ -26,8 +26,8 @@ def test_reading_and_conv_to_woollam(datadir):
     data_wvase = elli.read_woollam_rho(datadir / "wvase_example.dat")
     data_cease = elli.read_woollam_rho(datadir / "complete_ease_example.dat")
 
-    assert data_wvase.shape == (542,)
-    assert data_cease.shape == (3263,)
+    assert data_wvase.shape == (543,)
+    assert data_cease.shape == (3264,)
 
 
 # pylint: disable=redefined-outer-name


### PR DESCRIPTION
- Fixes file-type regex for negative delta values
- Fixes off-by-one error, which ignored the first data line